### PR TITLE
Un-break column indexing with new reduction behavior

### DIFF
--- a/lib/Spreadsheet/XLSX/Worksheet.rakumod
+++ b/lib/Spreadsheet/XLSX/Worksheet.rakumod
@@ -45,7 +45,9 @@ class Spreadsheet::XLSX::Worksheet {
         method idx-from-colref(Str:D $colref --> UInt:D) {
             my @chars = $colref.comb;
             die "Invalid column reference '$colref'" unless "A" le @chars.all le "Z";
-            @chars.map(*.ord - 65).cache andthen (|.head(*-1).map(* + 1), .tail).reduce({ $^a *26 + $^b })
+            my @high-place-values = @chars.head(*-1).map(*.ord - 'A'.ord + 1);
+            my $lowest-place-value = @chars.tail.ord - 'A'.ord;
+            @high-place-values.Slip andthen ($_, $lowest-place-value).reduce({ $^a * 26 + $^b }) orelse $lowest-place-value
         }
 
         #| Convert a 0-based index into column reference (name)


### PR DESCRIPTION
Fixes #28 .

It's quite unfortunate that [design changes can unfold from github discussions about a bug report](https://github.com/rakudo/rakudo/issues/1705#issuecomment-2122279730) - nothing wrong with the content in my opinion, the workflow itself is broken - but having come this far, I hope that it either stays this way, or at least we can get the current de facto behavior in some later version, so I went ahead and brought this library up to date with the current de facto standard.

Minuscule change - as you can see, it was quite magical and convoluted even before because the last position needs to be handled separately. I simply separated the cases when there is no prior letter, only the last, specially handled one, and when there actually are preceding letters.